### PR TITLE
Fix building of MV88X3310 with DKMS

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,8 +1,8 @@
 PACKAGE_NAME=tn40xx
 PACKAGE_VERSION=003
 BUILT_MODULE_NAME[0]="$PACKAGE_NAME"
-MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
-CLEAN="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+MAKE[0]="make build"
+CLEAN="make clean"
 DEST_MODULE_LOCATION[0]=/extra
 REMAKE_INITRD=no
 AUTOINSTALL=yes


### PR DESCRIPTION
Signed-off-by: Jonathan Bennett <JBennett@incomsystems.biz>
I have a card that uses the MV88X3310 chip, and have located the appropriate firmware file and added it to my source directory. DKMS was failing to find and process that firmware file, because the dkms build instructions were changing the current directory before the Makefile had a chance to test for the hdr file's existence. This is a potential workaround, tested to work on CentOS 8.