### PR TITLE
fix DKMS build for specific kernel version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #######################################
 
 PWD           := $(shell pwd)
-KVERSION      := $(shell uname -r)
+KVERSION      ?= $(shell uname -r)
 EXPECTED_KDIR := /lib/modules/$(KVERSION)/build
 OLDINSTDIR       := /lib/modules/$(KVERSION)/kernel/drivers/net
 INSTDIR          := /lib/modules/$(KVERSION)/kernel/drivers/net/tehuti

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,8 +1,8 @@
 PACKAGE_NAME=tn40xx
 PACKAGE_VERSION=004
 BUILT_MODULE_NAME[0]="$PACKAGE_NAME"
-MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
-CLEAN="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build KVERSION=${kernelver}"
+CLEAN="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build KVERSION=${kernelver} clean"
 DEST_MODULE_LOCATION[0]=/extra
 REMAKE_INITRD=no
 AUTOINSTALL=yes


### PR DESCRIPTION
This fixes build when you specify DKMS version with `-k` argument for `dkms install`.

Without this fix Makefile tries to look for kernel sources for currently running kernel version, not the one specified for `dkms install`.