### PR TITLE
kernel 5.7 upward

### DIFF
--- a/tn40.c
+++ b/tn40.c
@@ -4957,6 +4957,9 @@ static void bdx_ethtool_ops(struct net_device *netdev)
 #endif
 		.get_drvinfo = bdx_get_drvinfo,
 		.get_link = ethtool_op_get_link,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 7, 0)
+		.supported_coalesce_params = ETHTOOL_COALESCE_USECS,
+#endif
 		.get_coalesce = bdx_get_coalesce,
 		.set_coalesce = bdx_set_coalesce,
 		.get_ringparam = bdx_get_ringparam,


### PR DESCRIPTION
Use check pick from tn40xx-driver-004 so drivers is operational with Ubuntu 20.04.2 LTS and Kernel 5.8.0-53

This branch can be used with latest Ubuntu kernel and avoid memory leak.