### PR TITLE
Fix initialization failure when phy_mdio_port is 0

### DIFF
--- a/tn40.c
+++ b/tn40.c
@@ -441,7 +441,7 @@ static enum PHY_TYPE bdx_phy_init(struct bdx_priv *priv)
 
 	phy_id = bdx_mdio_scan_phy_id(priv);	/* set phy_mdio_port */
 
-	if (!priv->phy_mdio_port)
+	if (!phy_id)
 		return PHY_TYPE_NA;	/* No PHY detected on MDIO bus. */
 
 	/* register the PHY-specific callbacks */
@@ -460,7 +460,7 @@ static enum PHY_TYPE bdx_phy_init(struct bdx_priv *priv)
 
 	bdx_mdio_set_speed(priv->pBdxRegs, priv->phy_ops.mdio_speed);
 
-	if (priv->phy_ops.mdio_reset(priv, 1, priv->phy_type))
+	if (priv->phy_ops.mdio_reset(priv, priv->phy_mdio_port, priv->phy_type))
 		return PHY_TYPE_NA;
 
 	return phy_type;


### PR DESCRIPTION
This fixes an issue I reproduced with my TRENDnet TEG-10GECTX v2.0R and the driver from branch `release/linux-6.7.y-1` running on Linux 6.8.

This card has  Device ID 4027, Subsystem Device ID 3015.

With my card; the `for` loop in `bdx_mdio_scan_phy_id` completes on the very first iteration, which means the resulting value of `i` is `0`, which is then assigned to  `priv->phy_mdio_port`. 

When the port is set to 0, the if condition `!priv->phy_mdio_port` is true in `bdx_phy_init`, which results in an immediate return and failed detection of the PHY.

If I understand correctly, there may be up to 32 MDIO ports, but these are represented as values 0 to 31 in `phy_mdio_port`. Thus `0` is a valid port and should not result in a failure. 

I changed the if condition in question to use the return value of `bdx_mdio_scan_phy_id` instead. This value is `0` when the for loop has completed 32 iterations without finding a PHY.

I also found that the call to `priv->phy_ops.mdio_reset` on line 463 was hard-coded to use a port number of `1` rather than the detected port number stored in `phy_mdio_port`. Adjusted the same.

The driver initialization completes successfully with these changes in my own testing.